### PR TITLE
fixed bug where rink would not render on multiple axes

### DIFF
--- a/mplhockey/base/rink.py
+++ b/mplhockey/base/rink.py
@@ -122,7 +122,7 @@ class Rink:
             1) fig : matplotlib figure
             2) ax : matplotlib axis
         """
-        if self.ax is not None:
+        if (ax is None) and (self.ax is not None):
             return None, self.ax
 
         if ax is None:


### PR DESCRIPTION
Fixing [this reported issue](https://github.com/mlsedigital/mplhockey/issues/1) where mutliple axes would not allow drawing.

Particularly, something like this,

```python
import matplotlib.pyplot as plt
from mplhockey import NHLRink

fig, (ax1, ax2) = plt.subplots(1, 2, figsize=(14, 6))

rink = NHLRink()
rink.draw(ax=ax1)  # draws correctly to ax1
rink.draw(ax=ax2)  # expected: draws to ax2 — actual: draws to ax1 again

plt.show()
```

Should put the plot on both axes, but it was not. THank you, [bobby-king3](https://github.com/bobby-king3) for the issue!